### PR TITLE
Add ability to query bounding box of features by id

### DIFF
--- a/controllers/features.js
+++ b/controllers/features.js
@@ -18,18 +18,20 @@ exports.upsert = function(req, res) {
         });
     });
 };
+*/
 
 exports.getById = function(req, res) {
-    services.activities.get(req.params.userId, req.params.activityId, function(err, activity) {
+    let query = {
+        id: req.query.id.split(','),
+        include: req.query.include
+    };
+
+    services.features.getById(query, (err, features) => {
         if (err) return common.utils.handleError(res, err);
 
-        services.activities.toJsonApi(activity, function(err, activityJson) {
-            if (err) return common.utils.handleError(res, err);
-            res.send(activityJson);
-        });
+        res.send({ "features": features });
     });
 };
-*/
 
 exports.getByPoint = function(req, res) {
     let query = {

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ app.use(cors());
 app.use(morgan("combined", { "stream": log.stream }));
 app.use(bodyParser.json({ limit: '50mb' }));
 
+app.get('/features/id/:id',                         controllers.features.getById);
 app.get('/features/bbox/:north/:west/:south/:east', controllers.features.getByBoundingBox);
 app.get('/features/point/:latitude/:longitude',     controllers.features.getByPoint);
 app.get('/features/name/:name',                     controllers.features.getByName);

--- a/services/features.js
+++ b/services/features.js
@@ -33,12 +33,13 @@ function executeQuery(query, callback) {
 }
 
 function getById(query, callback) {
-    let getQuery = `SELECT ${buildQueryColumns(query)} FROM features WHERE id = ${escapeSql(query.id)}`;
+    const ids = query.id.constructor === Array ? query.id : [query.id];
+    const getQuery = `SELECT ${buildQueryColumns(query)} FROM features WHERE id IN (${escapeSql(ids.join(','))})`;
     executeQuery(getQuery, (err, rows) => {
         if (err) return callback(err);
         if (!rows || rows.length === 0) return callback(null, null);
 
-        return callback(null, rows[0]);
+        return callback(null, rows);
     });
 }
 

--- a/services/featuresCosmosDb.js
+++ b/services/featuresCosmosDb.js
@@ -113,12 +113,13 @@ function init(callback) {
 }
 
 function getById(query, callback) {
-    let getQuery = `SELECT ${buildQueryColumns(query)} FROM features WHERE id = ${escapeSql(query.id)}`;
+    const ids = query.id.constructor === Array ? query.id : [query.id];
+    const getQuery = `SELECT ${buildQueryColumns(query)} FROM features WHERE id IN (${escapeSql(ids.join(','))})`;
     executeQuery(getQuery, (err, rows) => {
         if (err) return callback(err);
         if (!rows || rows.length === 0) return callback(null, null);
 
-        return callback(null, rows[0]);
+        return callback(null, rows);
     });
 }
 

--- a/test/functional/features.js
+++ b/test/functional/features.js
@@ -108,4 +108,27 @@ describe('features endpoint', function() {
             done();
         });
     });
+
+    it('can get features by id', function(done) {
+        request.get(`${featuresEndpoint}/id/fake-3830198`, {
+            headers: {
+                Authorization: "Bearer " + fixtures.accessToken
+            },
+            json: true
+        }, function(err, resp) {
+            assert(!err);
+            assert.equal(resp.statusCode, HttpStatus.OK);
+
+            assert(resp.body.features);
+            assert(resp.body.features.length > 0);
+
+            let feature = resp.body.features[0];
+
+            assert.equal(feature.id, fixtures.feature.id);
+            assert.equal(feature.name, fixtures.feature.name);
+            assert.equal(feature.layer, fixtures.feature.layer);
+
+            done();
+        });
+    });
 });


### PR DESCRIPTION
For Fortis we need the ability to look up a feature's bounding box by that feature's id.

This pull request implements that functionality by:
1) Adding a new route to fetch one or more features by id
2) Adding a new include parameter to compute the bounding box in PostGIS and add it to the feature

Sample response ([openstreetmap](http://www.openstreetmap.org/?minlon=-74.261055&minlat=40.488998&maxlon=-73.6621286&maxlat=40.9176636&box=yes)):

![image](https://user-images.githubusercontent.com/1086421/27934879-c1ad2af0-625c-11e7-9d86-7745bd84a4ef.png)