### PR TITLE
Add ability to connect to Azure-hosted Postgres

### DIFF
--- a/services/features.js
+++ b/services/features.js
@@ -5,11 +5,9 @@ const async = require('async'),
       common = require('service-utils'),
       GeoPoint = require('geopoint'),
       HttpStatus = require('http-status-codes'),
-      pg = require('pg'),
-      process = require('process'),
+      postgres = require('./postgres'),
       ServiceError = common.utils.ServiceError,
-      turf = require('turf'),
-      url = require('url');
+      turf = require('turf');
 
 let featureDatabasePool;
 
@@ -118,23 +116,14 @@ function getByName(query, callback) {
 }
 
 function init(callback) {
-    if (!process.env.FEATURES_CONNECTION_STRING)
-        return callback(new ServiceError(HttpStatus.INTERNAL_SERVER_ERROR, "FEATURES_CONNECTION_STRING configuration not provided as environment variable"));
+    postgres.init(function(err, pool) {
+        if (err) {
+            return callback(err);
+        }
 
-    const params = url.parse(process.env.FEATURES_CONNECTION_STRING);
-    const auth = params.auth.split(':');
-
-    const config = {
-        user: auth[0],
-        password: auth[1],
-        host: params.hostname,
-        port: params.port,
-        database: params.pathname.split('/')[1]
-    };
-
-    featureDatabasePool = new pg.Pool(config);
-
-    return callback();
+        featureDatabasePool = pool;
+        return callback();
+    });
 }
 
 /*

--- a/services/postgres.js
+++ b/services/postgres.js
@@ -1,5 +1,6 @@
 const pg = require('pg'),
       process = require('process'),
+      querystring = require('querystring'),
       url = require('url');
 
 function init(callback) {
@@ -11,6 +12,7 @@ function init(callback) {
     }
 
     const params = url.parse(connectionString);
+    const query = querystring.parse(params.query);
     const auth = params.auth.split(':');
 
     const config = {
@@ -18,6 +20,7 @@ function init(callback) {
         password: auth[1],
         host: params.hostname,
         port: params.port,
+        ssl: query['ssl'],
         database: params.pathname.split('/')[1]
     };
 

--- a/services/postgres.js
+++ b/services/postgres.js
@@ -1,0 +1,31 @@
+const pg = require('pg'),
+      process = require('process'),
+      url = require('url');
+
+function init(callback) {
+    const connectionString = process.env.FEATURES_CONNECTION_STRING;
+
+    if (!connectionString) {
+        const err = new ServiceError(HttpStatus.INTERNAL_SERVER_ERROR, "FEATURES_CONNECTION_STRING configuration not provided as environment variable");
+        return callback(err);
+    }
+
+    const params = url.parse(connectionString);
+    const auth = params.auth.split(':');
+
+    const config = {
+        user: auth[0],
+        password: auth[1],
+        host: params.hostname,
+        port: params.port,
+        database: params.pathname.split('/')[1]
+    };
+
+    const featureDatabasePool = new pg.Pool(config);
+
+    return callback(null, featureDatabasePool);
+}
+
+module.exports = {
+    init: init
+};


### PR DESCRIPTION
This pull request adds SSL support to the featureService since Azure-hosted Postgres requires all connections to be made securely.

To facilitate the change, the duplicate Postgres initialization code is extracted to a helper that is referenced from `visits.js` and `features.js`.