### PR TITLE
Fix bugs in getById

### DIFF
--- a/controllers/features.js
+++ b/controllers/features.js
@@ -22,7 +22,7 @@ exports.upsert = function(req, res) {
 
 exports.getById = function(req, res) {
     let query = {
-        id: req.query.id.split(','),
+        id: req.params.id.split(','),
         include: req.query.include
     };
 

--- a/services/features.js
+++ b/services/features.js
@@ -32,7 +32,7 @@ function executeQuery(query, callback) {
 
 function getById(query, callback) {
     const ids = query.id.constructor === Array ? query.id : [query.id];
-    const getQuery = `SELECT ${buildQueryColumns(query)} FROM features WHERE id IN (${escapeSql(ids.join(','))})`;
+    const getQuery = `SELECT ${buildQueryColumns(query)} FROM features WHERE id IN (${ids.map(escapeSql).join(',')})`;
     executeQuery(getQuery, (err, rows) => {
         if (err) return callback(err);
         if (!rows || rows.length === 0) return callback(null, null);


### PR DESCRIPTION
Two fixes:
1) The controller is defined as `/features/id/:id` so the ids should come from the params, not the query.
2) The IN clause should get escaped like `('id1','id2')` not `('id1,id2')` as previously done.