### PR TITLE
Remove assumption that server is run from root

### DIFF
--- a/controllers/ops.js
+++ b/controllers/ops.js
@@ -1,11 +1,12 @@
 "use strict";
 
 let fs = require('fs');
+let path = require('path');
 
 let services = require('../services');
 
 let deploymentSHA;
-fs.readFile('./deployment_sha', 'utf8', (err, sha) => {
+fs.readFile(path.join(__dirname, '..', 'deployment_sha'), 'utf8', (err, sha) => {
     deploymentSHA = sha.trim();
 });
 


### PR DESCRIPTION
Previously, reading the deployment_sha file assumed that the server is always run via `node server.js` from the root directory of the service and would crash if this is not the case.

In some environments, we may not want to invoke the service in that way, for example because we want to provide an absolute path to the server.js file. This change supports that use-case.