### PR TITLE
Add one-click install script for project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,50 @@
-featureService
-==============
+# featureService #
 
-Development Setup
-=====
+## Development setup ##
+
+### System dependencies ###
+
 In order to install on your local machine, you will need to install:
 
-1. Postgres + postgis ([instructions for Ubuntu 16.04](http://www.gis-blog.com/how-to-install-postgis-2-3-on-ubuntu-16-04-lts/))
-2. Node ([instructions for Ubuntu 16.04](https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-ubuntu-16-04))
+- Postgres + postgis ([instructions for Ubuntu 16.04](http://www.gis-blog.com/how-to-install-postgis-2-3-on-ubuntu-16-04-lts/))
+- Node ([instructions for Ubuntu 16.04](https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-ubuntu-16-04))
 
-Once those are installed, go open a bash shell on the project directory and type:
+### Database setup ###
 
-```
-psql postgres
-```
+Once the system dependencies are installed, go open a bash shell on the project directory and set up the database:
 
-You will be welcomed with the postgres prompt. Now, create the geofeatures database and switch to it:
-
-```
-CREATE DATABASE geofeatures;
-\c geofeatures;
-
-CREATE USER frontend PASSWORD your_password_here;
-```
-
-Next, load the database schema:
-
-```
-psql -d geofeatures < schema.sql
+```sh
+cat << EOF | sudo -u postgres psql
+CREATE DATABASE features;
+CREATE USER frontend WITH login password 'your_password_here';
+CREATE USER ops WITH login password 'your_other_password_here';
+GRANT ops TO postgres;
+GRANT frontend TO postgres;
+EOF
+sudo -u postgres psql -d features < schema.sql
 ```
 
-Make sure the frontend user has access to the geofeatures database:
+### Application setup ###
 
-```
-GRANT ALL PRIVILEGES ON DATABASE geofeatures TO frontend;
-```
+First, make sure the environment variables for the service are set:
 
-Then, make sure the environment variable for the newly-created user is set:
-
-```
-export FEATURES_CONNECTION_STRING='postgres://frontend:your_password_here@127.0.0.1/geofeatures'
+```sh
+export FEATURES_CONNECTION_STRING='postgres://frontend:your_password_here@127.0.0.1/features'
 export PORT=3035
 ```
 
-Now, make sure the nodejs dependencies are installed:
+Now you're ready to install and start the service:
 
-```
+```sh
 npm install
-```
-
-Running
-=======
-All you need to do is run:
-
-```
 node server.js
 ```
+
+## Production setup ##
+
+You can run the script `scripts/install.sh` to set up a production machine with the featureService and all its dependencies. The script will:
+
+- Install postgres and postgis
+- Populate the postgres features database
+- Install the featureService
+- Autostart the featureService on port 80

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# configuration
+SCHEMA_VERSION='327df67'
+DUMP_VERSION='v2'
+
+# setup
+build_dependencies='curl git build-essential'
+sudo apt-get update > /dev/null
+sudo apt-get install -y ${build_dependencies} > /dev/null
+
+# install postgres
+ops_password="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)"
+frontend_password="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)"
+sudo apt-get install -y postgresql postgis > /dev/null
+sudo systemctl enable postgresql
+sudo service postgresql start
+echo "CREATE DATABASE features;" | sudo -u postgres psql
+echo "CREATE USER ops WITH login password 'changeme';" | sudo -u postgres psql
+echo "CREATE USER frontend WITH login password 'changeme';" | sudo -u postgres psql
+echo "ALTER USER ops WITH password '${ops_password}';" | sudo -u postgres psql
+echo "ALTER USER frontend WITH password '${frontend_password}';" | sudo -u postgres psql
+echo "GRANT ops TO postgres;" | sudo -u postgres psql
+echo "GRANT frontend TO postgres;" | sudo -u postgres psql
+curl -sL "https://raw.githubusercontent.com/CatalystCode/featureService/${SCHEMA_VERSION}/schema.sql" | sudo -u postgres psql -qd features
+
+# populate postgres
+dbdump="$(mktemp)"
+time_download_start="$(date +%s)"; echo "Starting to populate features database, this may take a while"
+curl -Lo "${dbdump}.gz" "https://fortiscentral.blob.core.windows.net/locations/feature-service.${DUMP_VERSION}.sql.gz"; gunzip -f "${dbdump}.gz"
+time_download_end="$(date +%s)"; echo "Seconds to download dump: $((time_download_end-time_download_start))"
+sudo -u postgres psql -qd features < "${dbdump}"
+time_insert_end="$(date +%s)"; echo "Seconds to populate database: $((time_insert_end-time_download_end))"
+rm "${dbdump}"
+
+# install node
+curl -sL 'https://deb.nodesource.com/setup_6.x' | sudo -E bash -
+sudo apt-get install -y nodejs > /dev/null
+
+# enable binding to port 80
+sudo apt-get install -y authbind > /dev/null
+sudo touch '/etc/authbind/byport/80'
+sudo chown "${USER}:${USER}" '/etc/authbind/byport/80'
+sudo chmod 755 '/etc/authbind/byport/80'
+
+# install app
+if [ ! -d featureService ]; then
+  git clone --depth 1 'https://github.com/CatalystCode/featureService.git'
+  (cd featureService; npm install)
+fi
+
+# autostart app
+sudo apt-get install -y supervisor > /dev/null
+sudo systemctl enable supervisor
+sudo service supervisor start
+sudo tee '/etc/supervisor/conf.d/featureService.conf' > /dev/null << EOF
+[program:featureService]
+command=/usr/bin/authbind "$(which node)" "$(readlink -f featureService/server.js)"
+autostart=true
+autorestart=true
+startretries=3
+stderr_logfile=/tmp/featureService.err.log
+stdout_logfile=/tmp/featureService.out.log
+user=${USER}
+environment=PORT=80,FEATURES_CONNECTION_STRING="postgres://frontend:${frontend_password}@127.0.0.1/features"
+EOF
+sudo supervisorctl reread
+sudo supervisorctl update
+
+# cleanup
+sudo apt-get remove -y ${build_dependencies} > /dev/null
+sudo apt-get autoremove -y > /dev/null
+sudo apt-get upgrade -y


### PR DESCRIPTION
The featureService is not super easy to set up: one must install postgres, postgis, populate the database, install the node service, etc. As such, it's worth automating the process to make it easier to set up a
new instance of the featureService; that's what the new `install.sh` script does.

The script installs postgres and the featureService app on the same host so that we don't have to manage multiple servers for the database and application layers. The featureService is exposed over port 80 so that postgres's port can be hidden in the firewall and we don't have to worry about securing the database.

An alternative to the `install.sh` script that I considered was using Docker. However, Azure Web Apps for Linux doesn't seem to support docker-compose yet and it would be an anti-pattern to have a single Docker image that contains the database and the application. So for now, the good-old bash script to set up a new machine will have to do.