### PR TITLE
Add documentation for x/y of centroid

### DIFF
--- a/services/features.js
+++ b/services/features.js
@@ -71,8 +71,8 @@ function parseCentroid(centroid_geo_json) {
         return null;
     }
 
-    const x = coords[0];
-    const y = coords[1];
+    const x = coords[0]; // longitude
+    const y = coords[1]; // latitude
 
     return [x, y];
 }


### PR DESCRIPTION
According to the [GeoJSON spec](https://geojson.org/geojson-spec.html#id2), the first element is the longitude and the second element is the latitude. This change just makes that a bit more evident in the code.