### PR TITLE
Add query parameter to filter results by name

### DIFF
--- a/controllers/features.js
+++ b/controllers/features.js
@@ -74,6 +74,7 @@ exports.getByBoundingBox = function(req, res) {
         west: parseFloat(req.params.west),
         south: parseFloat(req.params.south),
         east: parseFloat(req.params.east),
+        filter_name: req.query.filter_name,
         include: req.query.include
     };
 

--- a/services/features.js
+++ b/services/features.js
@@ -127,6 +127,10 @@ function addQueryPredicates(sql, query) {
         sql += ` AND layer = ${escapeSql(query.layer)}`;
     }
 
+    if (query.filter_name) {
+        sql += ` AND strpos(lower(name), ${escapeSql(query.filter_name.toLowerCase())}) > 0`;
+    }
+
     return sql;
 }
 

--- a/services/features.js
+++ b/services/features.js
@@ -122,15 +122,21 @@ function buildQueryColumns(query) {
     return queryColumns;
 }
 
+function addQueryPredicates(sql, query) {
+    if (query.layer) {
+        sql += ` AND layer = ${escapeSql(query.layer)}`;
+    }
+
+    return sql;
+}
+
 function getByBoundingBox(query, callback) {
     let boundingBoxQuery = `SELECT ${buildQueryColumns(query)} FROM features WHERE ST_Intersects(hull, ST_MakeEnvelope(
         ${query.west}, ${query.south},
         ${query.east}, ${query.north}, 4326
     ))`;
 
-    if (query.layer) {
-        boundingBoxQuery += ` AND layer=${escapeSql(query.layer)}`;
-    }
+    boundingBoxQuery = addQueryPredicates(boundingBoxQuery, query);
 
     return executeQuery(boundingBoxQuery, callback);
 }
@@ -140,9 +146,7 @@ function getByPoint(query, callback) {
         'POINT(${query.longitude} ${query.latitude})', 4326)
     )`;
 
-    if (query.layer) {
-        pointQuery += ` AND layer=${escapeSql(query.layer)}`;
-    }
+    pointQuery = addQueryPredicates(pointQuery, query);
 
     return executeQuery(pointQuery, callback);
 }
@@ -155,9 +159,7 @@ function getByName(query, callback) {
     }).join(" OR ")})`;
     let nameQuery = `SELECT ${buildQueryColumns(query)} FROM features WHERE ${namesDisjunction}`;
 
-    if (query.layer) {
-        nameQuery += ` AND layer=${escapeSql(query.layer)}`;
-    }
+    nameQuery = addQueryPredicates(nameQuery, query);
 
     executeQuery(nameQuery, callback);
 }

--- a/services/features.js
+++ b/services/features.js
@@ -150,9 +150,9 @@ function getByPoint(query, callback) {
 function getByName(query, callback) {
     const names = query.name.constructor === Array ? query.name : [query.name];
 
-    let namesDisjunction = names.map(function(name) {
+    let namesDisjunction = `(${names.map(function(name) {
         return `lower(name) = ${escapeSql(name.toLowerCase())}`;
-    }).join(" OR ");
+    }).join(" OR ")})`;
     let nameQuery = `SELECT ${buildQueryColumns(query)} FROM features WHERE ${namesDisjunction}`;
 
     if (query.layer) {

--- a/services/features.js
+++ b/services/features.js
@@ -128,7 +128,7 @@ function addQueryPredicates(sql, query) {
     }
 
     if (query.filter_name) {
-        sql += ` AND strpos(lower(name), ${escapeSql(query.filter_name.toLowerCase())}) > 0`;
+        sql += ` AND strpos(lower(name), lower(${escapeSql(query.filter_name)})) > 0`;
     }
 
     return sql;


### PR DESCRIPTION
## What's this? ##

This pull request adds an additional query parameter called `filter_name` that lets users subsample the return values of the featureService to only those features whose name (partially) matches the provided string.

This is generally useful, e.g. imagine querying for all features in a bounding box or at a particular point but while already having an idea of the names of features that we want to retrieve. Additionally, the feature will be used in the Fortis dashboard for implementing auto-suggest in the place search pane.

## Sample usage ##

*Bounding box query without name filter:* 32 results
![image](https://user-images.githubusercontent.com/1086421/30099107-f0fea5b4-92e4-11e7-8f83-2eb05e76b100.png)

*Narrowing to just features matching "somali":* 3 results
![image](https://user-images.githubusercontent.com/1086421/30099096-d84a275a-92e4-11e7-8df4-60d4eda3ef6e.png)

[Try it live!](http://13.72.77.67/features/bbox/5.9559/45.818/10.4921/47.8084?filter_name=somali)

## Implementation notes ##

We use the Postgres `strpos` function instead of a wildcard `LIKE` as it usually leads to better query plans for substring queries. For example, the below query plans show that `strpos` is a good 10% faster at execution and 40x faster at planning than the equivalent wildcard `LIKE`.

```
features=# explain analyze select name from features where strpos(lower(name),'aris')>0 limit 2;
                                                    QUERY PLAN
------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.00..1.20 rows=2 width=11) (actual time=0.044..3.088 rows=2 loops=1)
   ->  Seq Scan on features  (cost=0.00..94295.52 rows=157781 width=11) (actual time=0.043..3.087 rows=2 loops=1)
         Filter: (strpos(lower((name)::text), 'aris'::text) > 0)
         Rows Removed by Filter: 2538
 Planning time: 0.055 ms
 Execution time: 3.107 ms
(6 rows)

features=# explain analyze select name from features where lower(name) like '%aris%' limit 2;
                                                  QUERY PLAN
--------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.00..4048.35 rows=2 width=11) (actual time=0.051..3.454 rows=2 loops=1)
   ->  Seq Scan on features  (cost=0.00..93112.16 rows=46 width=11) (actual time=0.051..3.454 rows=2 loops=1)
         Filter: (lower((name)::text) ~~ '%aris%'::text)
         Rows Removed by Filter: 2139
 Planning time: 0.260 ms
 Execution time: 3.472 ms
(6 rows)
```