### PR TITLE
Add option to filter results by namespace

### DIFF
--- a/controllers/features.js
+++ b/controllers/features.js
@@ -23,6 +23,7 @@ exports.upsert = function(req, res) {
 exports.getById = function(req, res) {
     let query = {
         id: req.params.id.split(','),
+        filter_namespace: req.query.filter_namespace,
         include: req.query.include
     };
 
@@ -37,6 +38,7 @@ exports.getByPoint = function(req, res) {
     let query = {
         latitude: parseFloat(req.params.latitude),
         longitude: parseFloat(req.params.longitude),
+        filter_namespace: req.query.filter_namespace,
         include: req.query.include
     };
 
@@ -54,6 +56,7 @@ exports.getByPoint = function(req, res) {
 exports.getByName = function(req, res) {
     let query = {
         name: req.params.name.split(/,(?=[^ ])/),
+        filter_namespace: req.query.filter_namespace,
         include: req.query.include
     };
 
@@ -75,6 +78,7 @@ exports.getByBoundingBox = function(req, res) {
         south: parseFloat(req.params.south),
         east: parseFloat(req.params.east),
         filter_name: req.query.filter_name,
+        filter_namespace: req.query.filter_namespace,
         include: req.query.include
     };
 

--- a/schema.sql
+++ b/schema.sql
@@ -25,6 +25,7 @@ CREATE TABLE features
 
 CREATE INDEX features_hull_index ON features USING gist (hull);
 CREATE INDEX features_name_lower_index ON features(lower(name));
+CREATE INDEX features_namespace_index ON features(lower(split_part(id, '-', 1)));
 
 GRANT SELECT, UPDATE, INSERT, DELETE ON features TO frontend;
 

--- a/services/features.js
+++ b/services/features.js
@@ -131,6 +131,10 @@ function addQueryPredicates(sql, query) {
         sql += ` AND strpos(lower(name), lower(${escapeSql(query.filter_name)})) > 0`;
     }
 
+    if (query.filter_namespace) {
+        sql += ` AND lower(split_part(id, '-', 1)) = lower(${escapeSql(query.filter_namespace)})`;
+    }
+
     return sql;
 }
 


### PR DESCRIPTION
We now have at least two data-sets in the featureService: Who's on First and Divipola. As such, we may want the ability to restrict results to just features from one of the two data-sets (e.g. in a Fortis deployment in Colombia we may want to only consider shapes from Divipola).

Try it live:
- [?filter_namespace=divipola](http://13.72.77.67/features/name/alto%20de%20lisboa?filter_namespace=divipola) to include only divipola dataset (returns 1 row)
- [?filter_namespace=wof](http://13.72.77.67/features/name/alto%20de%20lisboa?filter_namespace=wof) to include only wof dataset (returns 0 rows)

This change makes the assumption that we'll continue the current trend of prefixing all ids with the data source from where they came, so if an item has an id 1234 and came from the Who's on First dataset, we'll give it an id like `wof-1234`. This is a reasonable pattern so it's fine to make this assumption given that it lets us avoid having to deal with migrations for now.

Adding a computed index on the id column lets us query the namespace with a reasonable efficiency as the below query plan shows:

```
features=# explain analyze select id from features where lower(split_part(id,'-',1))='divipola';

                                                              QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------
 Bitmap Heap Scan on features  (cost=47.06..8406.97 rows=2405 width=13) (actual time=0.977..7.781 rows=5879 loops=1)
   Recheck Cond: (lower(split_part((id)::text, '-'::text, 1)) = 'divipola'::text)
   Heap Blocks: exact=1236
   ->  Bitmap Index Scan on features_namespace_index  (cost=0.00..46.46 rows=2405 width=0) (actual time=0.849..0.849 rows=5879 loops=1)
         Index Cond: (lower(split_part((id)::text, '-'::text, 1)) = 'divipola'::text)
 Planning time: 0.124 ms
 Execution time: 8.653 ms
```