### PR TITLE
Add filter for layer

### DIFF
--- a/controllers/features.js
+++ b/controllers/features.js
@@ -24,6 +24,7 @@ exports.getById = function(req, res) {
     let query = {
         id: req.params.id.split(','),
         filter_namespace: req.query.filter_namespace,
+        filter_layer: req.query.filter_layer,
         include: req.query.include
     };
 
@@ -39,6 +40,7 @@ exports.getByPoint = function(req, res) {
         latitude: parseFloat(req.params.latitude),
         longitude: parseFloat(req.params.longitude),
         filter_namespace: req.query.filter_namespace,
+        filter_layer: req.query.filter_layer,
         include: req.query.include
     };
 
@@ -57,6 +59,7 @@ exports.getByName = function(req, res) {
     let query = {
         name: req.params.name.split(/,(?=[^ ])/),
         filter_namespace: req.query.filter_namespace,
+        filter_layer: req.query.filter_layer,
         include: req.query.include
     };
 
@@ -79,6 +82,7 @@ exports.getByBoundingBox = function(req, res) {
         east: parseFloat(req.params.east),
         filter_name: req.query.filter_name,
         filter_namespace: req.query.filter_namespace,
+        filter_layer: req.query.filter_layer,
         include: req.query.include
     };
 

--- a/schema.sql
+++ b/schema.sql
@@ -26,6 +26,7 @@ CREATE TABLE features
 CREATE INDEX features_hull_index ON features USING gist (hull);
 CREATE INDEX features_name_lower_index ON features(lower(name));
 CREATE INDEX features_namespace_index ON features(lower(split_part(id, '-', 1)));
+CREATE INDEX features_layer_lower_index ON features(lower(layer));
 
 GRANT SELECT, UPDATE, INSERT, DELETE ON features TO frontend;
 

--- a/services/features.js
+++ b/services/features.js
@@ -135,6 +135,10 @@ function addQueryPredicates(sql, query) {
         sql += ` AND lower(split_part(id, '-', 1)) = lower(${escapeSql(query.filter_namespace)})`;
     }
 
+    if (query.filter_layer) {
+        sql += ` AND lower(layer) IN (${query.filter_layer.split(',').map(layer => `lower(${escapeSql(layer)})`).join(',')})`;
+    }
+
     return sql;
 }
 


### PR DESCRIPTION
This lets us for example exclude all features that are at a too high level (e.g. country or continent) by explicitly specifying all the layers that we care about and only getting results from those layers.

Try it live:
- [Include all "Boston" matches](http://13.72.77.67/features/name/boston)
- [Only include "Boston" at county level](http://13.72.77.67/features/name/boston?filter_layer=county)
- [Only include "Boston" at county and locality level](http://13.72.77.67/features/name/boston?filter_layer=county,locality)

The list of all layer is as follows:

```
features=# select count(*), layer from features group by layer order by count desc;
 count  |     layer
--------+---------------
 212672 | locality
 118725 | localadmin
  90320 | neighbourhood
  47008 | county
   4996 | region
   4423 | campus
   1666 | microhood
    375 | macrocounty
    351 | macrohood
    228 | country
    138 | borough
    109 | macroregion
     41 | disputed
     39 | dependency
      8 | continent
```

Knowledge of this list is useful if we only want to exclude particular layers since the features database doesn't have a concept of layer hierarchy at this point. A description of the layers can be found in the [Who's on First documentation](https://github.com/whosonfirst/whosonfirst-placetypes).