### PR TITLE
Replace escapeSql with pg built-in escaping

### DIFF
--- a/services/postgres.js
+++ b/services/postgres.js
@@ -3,10 +3,6 @@ const pg = require('pg'),
       querystring = require('querystring'),
       url = require('url');
 
-function escapeSql(value) {
-    return `'${value.replace(/'/g,"''")}'`;
-}
-
 function init(callback) {
     const connectionString = process.env.FEATURES_CONNECTION_STRING;
 
@@ -34,6 +30,5 @@ function init(callback) {
 }
 
 module.exports = {
-    escapeSql: escapeSql,
     init: init
 };


### PR DESCRIPTION
In https://github.com/CatalystCode/project-fortis-pipeline/issues/222 we discovered another set of SQL-injection attack vectors for the feature service. This commit fixes potential injection vulnerabilities once and for all by switching all queries to using the postgres built-in parameter interpolation mechanism instead of using string queries.

The changes were validated by calling the following routes which should be roughly representative of the entire functionality space of the featureService:

```sh
curl 'localhost:8080/features/name/paris'
curl 'localhost:8080/features/name/bogota,paris'
curl 'localhost:8080/features/id/wof-85971971'
curl 'localhost:8080/features/id/wof-404477281,wof-85971971'
curl 'localhost:8080/features/point/40.71/74.0'
curl 'localhost:8080/features/bbox/47/5/35/10'
curl 'localhost:8080/features/bbox/47/5/35/10?filter_name=Saint&filter_layer=campus'
```