### PR TITLE
Hide Postgres error messages

### DIFF
--- a/services/features.js
+++ b/services/features.js
@@ -13,15 +13,20 @@ let featureDatabasePool;
 
 function executeQuery(query, params, callback) {
     featureDatabasePool.connect((err, client, done) => {
-        if (err) return callback(err);
+        if (err) {
+            console.error(err);
+            return callback(new ServiceError(HttpStatus.INTERNAL_SERVER_ERROR, "Error connecting to the features DB"));
+        }
 
         client.query(query, params, (err, results) => {
             done();
 
-            if (err)
-                return callback(err);
-            else
+            if (err) {
+                console.error(err);
+                return callback(new ServiceError(HttpStatus.INTERNAL_SERVER_ERROR, "Error querying the features DB"));
+            } else {
                 return callback(null, resultsToFeatures(results));
+            }
         });
     });
 }

--- a/services/postgres.js
+++ b/services/postgres.js
@@ -1,6 +1,9 @@
 const pg = require('pg'),
       process = require('process'),
       querystring = require('querystring'),
+      HttpStatus = require('http-status-codes'),
+      common = require('service-utils'),
+      ServiceError = common.utils.ServiceError,
       url = require('url');
 
 function init(callback) {

--- a/services/postgres.js
+++ b/services/postgres.js
@@ -10,8 +10,7 @@ function init(callback) {
     const connectionString = process.env.FEATURES_CONNECTION_STRING;
 
     if (!connectionString) {
-        const err = new ServiceError(HttpStatus.INTERNAL_SERVER_ERROR, "FEATURES_CONNECTION_STRING configuration not provided as environment variable");
-        return callback(err);
+        return callback(new ServiceError(HttpStatus.INTERNAL_SERVER_ERROR, "Environment not set up to connect to DB"));
     }
 
     const params = url.parse(connectionString);

--- a/services/visits.js
+++ b/services/visits.js
@@ -48,15 +48,20 @@ function deleteByUserId(userId, callback) {
 
 function executeQuery(query, params, callback) {
     featureTablePool.connect((err, client, done) => {
-        if (err) return callback(err);
+        if (err) {
+            console.error(err);
+            return callback(new ServiceError(HttpStatus.INTERNAL_SERVER_ERROR, "Error connecting to the visits DB"));
+        }
 
         client.query(query, params, (err, results) => {
             done();
 
-            if (err)
-                return callback(err);
-            else
+            if (err) {
+                console.error(err);
+                return callback(new ServiceError(HttpStatus.INTERNAL_SERVER_ERROR, "Error querying the visits DB"));
+            } else {
                 return callback(null, resultsToVisits(results));
+            }
         });
     });
 }


### PR DESCRIPTION
According to @anthturner it's not good practice to expose detailed error messages from the database to clients as this makes it easier for an attacker to figure out potential attack vectors.

This pull request masks the Postgres error messages in favor of more generic ones that don't risk leaking sensitive information.